### PR TITLE
Add new endpoint to inspect container logs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -61,7 +61,7 @@
   revision = "28602af35aceda2f8d571bad7ca37a54cf0250bc"
 
 [[projects]]
-  digest = "1:c4c7064c2c67a0a00815918bae489dd62cd88d859d24c95115d69b00b3d33334"
+  digest = "1:c9fed74f616e2e018bfe5dc82efb592233873744b818c6422a01f25431ecdd5b"
   name = "github.com/docker/docker"
   packages = [
     "api/types",
@@ -79,6 +79,7 @@
     "api/types/versions",
     "api/types/volume",
     "client",
+    "pkg/stdcopy",
     "pkg/tlsconfig",
   ]
   pruneopts = "UT"
@@ -447,6 +448,7 @@
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/api/types/events",
     "github.com/docker/docker/client",
+    "github.com/docker/docker/pkg/stdcopy",
     "github.com/gorilla/securecookie",
     "github.com/mcnijman/go-emailaddress",
     "github.com/pusher/oauth2_proxy/pkg/apis/options",

--- a/logs.go
+++ b/logs.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+type LogInspector struct {
+	api  *client.Client
+	busy bool
+}
+
+func newLogsInspector() *LogInspector {
+	c, err := client.NewEnvClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &LogInspector{
+		api: c,
+	}
+}
+
+func (inspector LogInspector) renderLogs(ids []string, writer io.Writer) {
+	if inspector.busy {
+		fmt.Fprintln(writer, "another logs request is in progress")
+		return
+	}
+
+	inspector.busy = true
+	defer func() {
+		inspector.busy = false
+	}()
+
+	opts := types.ContainerLogsOptions{
+		Details:    false,
+		Timestamps: true,
+		Tail:       "1000",
+		ShowStdout: true,
+		ShowStderr: true,
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(ids))
+
+	buf := bytes.NewBuffer(nil)
+
+	for _, id := range ids {
+		go func(id string) {
+			defer wg.Done()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			reader, err := inspector.api.ContainerLogs(ctx, id, opts)
+			if err != nil {
+				fmt.Fprintf(writer, "container id=%q logs read failed: %s\n", id, err)
+				return
+			}
+			defer reader.Close()
+
+			if _, err := stdcopy.StdCopy(buf, buf, reader); err != nil {
+				fmt.Fprintf(writer, "container id=%q stdcopy failed: %s\n", id, err)
+			}
+		}(id)
+	}
+
+	wg.Wait()
+
+	writer.Write(buf.Bytes())
+}

--- a/logs.go
+++ b/logs.go
@@ -29,7 +29,7 @@ func newLogsInspector() *LogInspector {
 	}
 }
 
-func (inspector LogInspector) renderLogs(ids []string, writer io.Writer) {
+func (inspector *LogInspector) renderLogs(ids []string, writer io.Writer) {
 	if inspector.busy {
 		fmt.Fprintln(writer, "another logs request is in progress")
 		return

--- a/vendor/github.com/docker/docker/pkg/stdcopy/stdcopy.go
+++ b/vendor/github.com/docker/docker/pkg/stdcopy/stdcopy.go
@@ -1,0 +1,174 @@
+package stdcopy
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StdType is the type of standard stream
+// a writer can multiplex to.
+type StdType byte
+
+const (
+	// Stdin represents standard input stream type.
+	Stdin StdType = iota
+	// Stdout represents standard output stream type.
+	Stdout
+	// Stderr represents standard error steam type.
+	Stderr
+
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+
+	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
+)
+
+var bufPool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underneath writer.
+// It inserts the prefix header before the buffer,
+// so stdcopy.StdCopy knows where to multiplex the output.
+// It makes stdWriter to implement io.Writer.
+func (w *stdWriter) Write(p []byte) (n int, err error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	if p == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Write(header[:])
+	buf.Write(p)
+
+	n, err = w.Writer.Write(buf.Bytes())
+	n -= stdWriterPrefixLen
+	if n < 0 {
+		n = 0
+	}
+
+	buf.Reset()
+	bufPool.Put(buf)
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(t),
+	}
+}
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, startingBufLen)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// Check the first byte to know where to write
+		switch StdType(buf[stdWriterFdIndex]) {
+		case Stdin:
+			fallthrough
+		case Stdout:
+			// Write on stdout
+			out = dstout
+		case Stderr:
+			// Write on stderr
+			out = dsterr
+		default:
+			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+stdWriterPrefixLen > bufLen {
+			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
+		if ew != nil {
+			return 0, ew
+		}
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+stdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + stdWriterPrefixLen
+	}
+}


### PR DESCRIPTION
Going to http://myapp.com/_debug/logs will render logs from all associated containers (not in the right order though). Each log group includes up to 1k lines. 